### PR TITLE
Initial PostsConnection implementation. TARGETS #24

### DIFF
--- a/_scripts/migrations/0014_add_post_created_at_index.sql
+++ b/_scripts/migrations/0014_add_post_created_at_index.sql
@@ -1,1 +1,0 @@
-CREATE INDEX IF NOT EXISTS posts_created_at_askenkadss12vv ON posts (discussion_id, created_at);

--- a/_scripts/migrations/0014_add_post_created_at_index.sql
+++ b/_scripts/migrations/0014_add_post_created_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS posts_created_at_askenkadss12vv ON posts (discussion_id, created_at);

--- a/_scripts/migrations/0016_add_discussion_id_post_created_at_index.sql
+++ b/_scripts/migrations/0016_add_discussion_id_post_created_at_index.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX IF NOT EXISTS posts_discussion_id_created_at_askenkadss12vv ON posts (discussion_id, created_at);

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -49,7 +49,6 @@ type ResolverRoot interface {
 	Post() PostResolver
 	PostBookmark() PostBookmarkResolver
 	PostBookmarksConnection() PostBookmarksConnectionResolver
-	PostsConnection() PostsConnectionResolver
 	Query() QueryResolver
 	Subscription() SubscriptionResolver
 	Tag() TagResolver
@@ -86,6 +85,7 @@ type ComplexityRoot struct {
 		Moderator               func(childComplexity int) int
 		Participants            func(childComplexity int) int
 		Posts                   func(childComplexity int) int
+		PostsConnection         func(childComplexity int, after *string) int
 		Tags                    func(childComplexity int) int
 		Title                   func(childComplexity int) int
 		UpcomingContent         func(childComplexity int) int
@@ -232,9 +232,8 @@ type ComplexityRoot struct {
 	}
 
 	PostsConnection struct {
-		Edges      func(childComplexity int) int
-		PageInfo   func(childComplexity int) int
-		TotalCount func(childComplexity int) int
+		Edges    func(childComplexity int) int
+		PageInfo func(childComplexity int) int
 	}
 
 	PostsEdge struct {
@@ -329,6 +328,7 @@ type DiscussionResolver interface {
 	Moderator(ctx context.Context, obj *model.Discussion) (*model.Moderator, error)
 
 	Posts(ctx context.Context, obj *model.Discussion) ([]*model.Post, error)
+	PostsConnection(ctx context.Context, obj *model.Discussion, after *string) (*model.PostsConnection, error)
 
 	Participants(ctx context.Context, obj *model.Discussion) ([]*model.Participant, error)
 
@@ -402,9 +402,6 @@ type PostBookmarkResolver interface {
 }
 type PostBookmarksConnectionResolver interface {
 	Edges(ctx context.Context, obj *model.PostBookmarksConnection) ([]*model.PostBookmarksEdge, error)
-}
-type PostsConnectionResolver interface {
-	Edges(ctx context.Context, obj *model.PostsConnection) ([]*model.PostsEdge, error)
 }
 type QueryResolver interface {
 	Discussion(ctx context.Context, id string) (*model.Discussion, error)
@@ -585,6 +582,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Discussion.Posts(childComplexity), true
+
+	case "Discussion.postsConnection":
+		if e.complexity.Discussion.PostsConnection == nil {
+			break
+		}
+
+		args, err := ec.field_Discussion_postsConnection_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Discussion.PostsConnection(childComplexity, args["after"].(*string)), true
 
 	case "Discussion.tags":
 		if e.complexity.Discussion.Tags == nil {
@@ -1324,13 +1333,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PostsConnection.PageInfo(childComplexity), true
 
-	case "PostsConnection.totalCount":
-		if e.complexity.PostsConnection.TotalCount == nil {
-			break
-		}
-
-		return e.complexity.PostsConnection.TotalCount(childComplexity), true
-
 	case "PostsEdge.cursor":
 		if e.complexity.PostsEdge.Cursor == nil {
 			break
@@ -1737,6 +1739,7 @@ var sources = []*ast.Source{
     
     # A link to all posts in the discussion, ordered chronologically.
     posts: [Post!]
+    postsConnection(after: ID): PostsConnection!
 
     iconURL: String
 
@@ -1976,7 +1979,6 @@ type PostBookmark {
     node: PostBookmark
 }`, BuiltIn: false},
 	&ast.Source{Name: "graph/types/posts_connection.graphqls", Input: `type PostsConnection {
-    totalCount: Int!
     edges: [PostsEdge!]
     pageInfo: PageInfo!
 }`, BuiltIn: false},
@@ -2174,6 +2176,20 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_Discussion_postsConnection_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *string
+	if tmp, ok := rawArgs["after"]; ok {
+		arg0, err = ec.unmarshalOID2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["after"] = arg0
+	return args, nil
+}
 
 func (ec *executionContext) field_Mutation_addDiscussionParticipant_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
@@ -3031,6 +3047,47 @@ func (ec *executionContext) _Discussion_posts(ctx context.Context, field graphql
 	res := resTmp.([]*model.Post)
 	fc.Result = res
 	return ec.marshalOPost2ᚕᚖgithubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Discussion_postsConnection(ctx context.Context, field graphql.CollectedField, obj *model.Discussion) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "Discussion",
+		Field:    field,
+		Args:     nil,
+		IsMethod: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	rawArgs := field.ArgumentMap(ec.Variables)
+	args, err := ec.field_Discussion_postsConnection_args(ctx, rawArgs)
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	fc.Args = args
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Discussion().PostsConnection(rctx, obj, args["after"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.PostsConnection)
+	fc.Result = res
+	return ec.marshalNPostsConnection2ᚖgithubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Discussion_iconURL(ctx context.Context, field graphql.CollectedField, obj *model.Discussion) (ret graphql.Marshaler) {
@@ -6394,40 +6451,6 @@ func (ec *executionContext) _PostBookmarksEdge_node(ctx context.Context, field g
 	return ec.marshalOPostBookmark2ᚖgithubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostBookmark(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _PostsConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *model.PostsConnection) (ret graphql.Marshaler) {
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	fc := &graphql.FieldContext{
-		Object:   "PostsConnection",
-		Field:    field,
-		Args:     nil,
-		IsMethod: true,
-	}
-
-	ctx = graphql.WithFieldContext(ctx, fc)
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.TotalCount(), nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(int)
-	fc.Result = res
-	return ec.marshalNInt2int(ctx, field.Selections, res)
-}
-
 func (ec *executionContext) _PostsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *model.PostsConnection) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -6439,13 +6462,13 @@ func (ec *executionContext) _PostsConnection_edges(ctx context.Context, field gr
 		Object:   "PostsConnection",
 		Field:    field,
 		Args:     nil,
-		IsMethod: true,
+		IsMethod: false,
 	}
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.PostsConnection().Edges(rctx, obj)
+		return obj.Edges, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -6470,13 +6493,13 @@ func (ec *executionContext) _PostsConnection_pageInfo(ctx context.Context, field
 		Object:   "PostsConnection",
 		Field:    field,
 		Args:     nil,
-		IsMethod: true,
+		IsMethod: false,
 	}
 
 	ctx = graphql.WithFieldContext(ctx, fc)
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.PageInfo(), nil
+		return obj.PageInfo, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -9454,6 +9477,20 @@ func (ec *executionContext) _Discussion(ctx context.Context, sel ast.SelectionSe
 				res = ec._Discussion_posts(ctx, field, obj)
 				return res
 			})
+		case "postsConnection":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Discussion_postsConnection(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "iconURL":
 			out.Values[i] = ec._Discussion_iconURL(ctx, field, obj)
 		case "participants":
@@ -10520,26 +10557,12 @@ func (ec *executionContext) _PostsConnection(ctx context.Context, sel ast.Select
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("PostsConnection")
-		case "totalCount":
-			out.Values[i] = ec._PostsConnection_totalCount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
-			}
 		case "edges":
-			field := field
-			out.Concurrently(i, func() (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._PostsConnection_edges(ctx, field, obj)
-				return res
-			})
+			out.Values[i] = ec._PostsConnection_edges(ctx, field, obj)
 		case "pageInfo":
 			out.Values[i] = ec._PostsConnection_pageInfo(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&invalids, 1)
+				invalids++
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
@@ -11691,6 +11714,20 @@ func (ec *executionContext) unmarshalNPostType2githubᚗcomᚋnedrocksᚋdelphis
 
 func (ec *executionContext) marshalNPostType2githubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostType(ctx context.Context, sel ast.SelectionSet, v model.PostType) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNPostsConnection2githubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostsConnection(ctx context.Context, sel ast.SelectionSet, v model.PostsConnection) graphql.Marshaler {
+	return ec._PostsConnection(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPostsConnection2ᚖgithubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostsConnection(ctx context.Context, sel ast.SelectionSet, v *model.PostsConnection) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._PostsConnection(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNPostsEdge2githubᚗcomᚋnedrocksᚋdelphisbeᚋgraphᚋmodelᚐPostsEdge(ctx context.Context, sel ast.SelectionSet, v model.PostsEdge) graphql.Marshaler {

--- a/graph/model/post.go
+++ b/graph/model/post.go
@@ -32,14 +32,11 @@ type PostsEdge struct {
 }
 
 type PostsConnection struct {
-	// from string
-	// to   string
+	Edges    []*PostsEdge `json:"edges"`
+	PageInfo PageInfo     `json:"pageInfo"`
 }
 
-func (p *PostsConnection) TotalCount() int {
-	return 0 //len(p.ids)
-}
-
+/*
 func (p *PostsConnection) PageInfo() PageInfo {
 	// 	from := EncodeCursor(p.from)
 	// 	to := EncodeCursor(p.to)
@@ -50,3 +47,4 @@ func (p *PostsConnection) PageInfo() PageInfo {
 	// 	}
 	return PageInfo{}
 }
+*/

--- a/graph/model/post.go
+++ b/graph/model/post.go
@@ -35,16 +35,3 @@ type PostsConnection struct {
 	Edges    []*PostsEdge `json:"edges"`
 	PageInfo PageInfo     `json:"pageInfo"`
 }
-
-/*
-func (p *PostsConnection) PageInfo() PageInfo {
-	// 	from := EncodeCursor(p.from)
-	// 	to := EncodeCursor(p.to)
-	// 	return PageInfo{
-	// 		StartCursor: &from,
-	// 		EndCursor:   &to,
-	// 		HasNextPage: p.to < len(p.ids),
-	// 	}
-	return PageInfo{}
-}
-*/

--- a/graph/resolver/discussion.resolvers.go
+++ b/graph/resolver/discussion.resolvers.go
@@ -36,13 +36,18 @@ func (r *discussionResolver) Posts(ctx context.Context, obj *model.Discussion) (
 }
 
 func (r *discussionResolver) PostsConnection(ctx context.Context, obj *model.Discussion, after *string) (*model.PostsConnection, error) {
-	limit := 2
+	/* Hardcode the number of posts per page. This can be changed to be settable by the client in the query. */
+	limit := 50
+
+	/* Sanity check. If no "after" parameter is specified, we set it to a time far into the future, for which
+	   no post can yet have been created (not even cosidering large clocks drift) */
 	if after == nil {
 		futureTime := time.Now().AddDate(1, 0, 0).Format(time.RFC3339)
 		after = &futureTime
 	} else if _, err := time.Parse(time.RFC3339, *after); err != nil {
 		return nil, errors.New("The 'After' parameter is badly formatted: " + *after)
 	}
+
 	return r.DAOManager.GetPostsConnectionByDiscussionID(ctx, obj.ID, *after, limit)
 }
 

--- a/graph/resolver/discussion.resolvers.go
+++ b/graph/resolver/discussion.resolvers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nedrocks/delphisbe/graph/generated"
 	"github.com/nedrocks/delphisbe/graph/model"
 	"github.com/nedrocks/delphisbe/internal/auth"
+	"github.com/nedrocks/delphisbe/internal/backend"
 )
 
 func (r *discussionResolver) Moderator(ctx context.Context, obj *model.Discussion) (*model.Moderator, error) {
@@ -37,7 +38,7 @@ func (r *discussionResolver) Posts(ctx context.Context, obj *model.Discussion) (
 
 func (r *discussionResolver) PostsConnection(ctx context.Context, obj *model.Discussion, after *string) (*model.PostsConnection, error) {
 	/* Hardcode the number of posts per page. This can be changed to be settable by the client in the query. */
-	limit := 50
+	limit := backend.PostPerPageLimit
 
 	/* Sanity check. If no "after" parameter is specified, we set it to a time far into the future, for which
 	   no post can yet have been created (not even cosidering large clocks drift) */

--- a/graph/resolver/discussion.resolvers.go
+++ b/graph/resolver/discussion.resolvers.go
@@ -5,6 +5,7 @@ package resolver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,6 +33,17 @@ func (r *discussionResolver) Posts(ctx context.Context, obj *model.Discussion) (
 	}
 
 	return posts, nil
+}
+
+func (r *discussionResolver) PostsConnection(ctx context.Context, obj *model.Discussion, after *string) (*model.PostsConnection, error) {
+	limit := 2
+	if after == nil {
+		futureTime := time.Now().AddDate(1, 0, 0).Format(time.RFC3339)
+		after = &futureTime
+	} else if _, err := time.Parse(time.RFC3339, *after); err != nil {
+		return nil, errors.New("The 'After' parameter is badly formatted: " + *after)
+	}
+	return r.DAOManager.GetPostsConnectionByDiscussionID(ctx, obj.ID, *after, limit)
 }
 
 func (r *discussionResolver) Participants(ctx context.Context, obj *model.Discussion) ([]*model.Participant, error) {

--- a/graph/resolver/posts_connection.resolvers.go
+++ b/graph/resolver/posts_connection.resolvers.go
@@ -5,19 +5,12 @@ package resolver
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/nedrocks/delphisbe/graph/generated"
 	"github.com/nedrocks/delphisbe/graph/model"
 )
 
 func (r *postsConnectionResolver) Edges(ctx context.Context, obj *model.PostsConnection) ([]*model.PostsEdge, error) {
-	panic(fmt.Errorf("not implemented"))
-}
-
-// PostsConnection returns generated.PostsConnectionResolver implementation.
-func (r *Resolver) PostsConnection() generated.PostsConnectionResolver {
-	return &postsConnectionResolver{r}
+	return obj.Edges, nil
 }
 
 type postsConnectionResolver struct{ *Resolver }

--- a/graph/types/discussion.graphqls
+++ b/graph/types/discussion.graphqls
@@ -9,6 +9,7 @@ type Discussion implements Entity {
     
     # A link to all posts in the discussion, ordered chronologically.
     posts: [Post!]
+    postsConnection(after: ID): PostsConnection!
 
     iconURL: String
 

--- a/graph/types/posts_connection.graphqls
+++ b/graph/types/posts_connection.graphqls
@@ -1,5 +1,4 @@
 type PostsConnection {
-    totalCount: Int!
     edges: [PostsEdge!]
     pageInfo: PageInfo!
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -53,6 +53,7 @@ type DelphisBackend interface {
 	PutImportedContentQueue(ctx context.Context, discussionID, contentID string, postedAt *time.Time, matchingTags []string, autoPost bool) (*model.ContentQueueRecord, error)
 	NotifySubscribersOfCreatedPost(ctx context.Context, post *model.Post, discussionID string) error
 	GetPostsByDiscussionID(ctx context.Context, discussionID string) ([]*model.Post, error)
+	GetPostsConnectionByDiscussionID(ctx context.Context, discussionID string, cursor string, limit int) (*model.PostsConnection, error)
 	GetLastPostByDiscussionID(ctx context.Context, discussionID string, minutes int) (*model.Post, error)
 	GetPostContentByID(ctx context.Context, id string) (*model.PostContent, error)
 	GetUserProfileByID(ctx context.Context, id string) (*model.UserProfile, error)

--- a/internal/backend/post.go
+++ b/internal/backend/post.go
@@ -15,6 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	PostPerPageLimit = 50
+)
+
 func (d *delphisBackend) CreatePost(ctx context.Context, discussionID string, participantID string, input model.PostContentInput) (*model.Post, error) {
 	// Validate input string if there are mentioned entities
 	if input.MentionedEntities != nil {
@@ -208,6 +212,9 @@ func (d *delphisBackend) GetLastPostByDiscussionID(ctx context.Context, discussi
 }
 
 func (d *delphisBackend) GetPostsConnectionByDiscussionID(ctx context.Context, discussionID string, cursor string, limit int) (*model.PostsConnection, error) {
+	if limit < 2 || limit > PostPerPageLimit {
+		return nil, errors.New("Values of 'limit' is illegal")
+	}
 	return d.db.GetPostsConnectionByDiscussionID(ctx, discussionID, cursor, limit)
 }
 

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -49,6 +49,8 @@ type Datastore interface {
 	UpsertParticipant(ctx context.Context, participant model.Participant) (*model.Participant, error)
 	GetPostsByDiscussionID(ctx context.Context, discussionID string) ([]*model.Post, error)
 	GetPostsByDiscussionIDIter(ctx context.Context, discussionID string) PostIter
+	GetPostsByDiscussionIDFromCursorIter(ctx context.Context, discussionID string, cursor string, limit int) PostIter
+	GetPostsConnectionByDiscussionID(ctx context.Context, discussionID string, cursor string, limit int) (*model.PostsConnection, error)
 	GetLastPostByDiscussionID(ctx context.Context, discussionID string, minutes int) (*model.Post, error)
 	GetPostContentByID(ctx context.Context, id string) (*model.PostContent, error)
 	PutPost(ctx context.Context, tx *sql2.Tx, post model.Post) (*model.Post, error)
@@ -81,6 +83,9 @@ type Datastore interface {
 	GetScheduledImportedContentByDiscussionID(ctx context.Context, discussionID string) ContentIter
 	PutImportedContentDiscussionQueue(ctx context.Context, discussionID, contentID string, postedAt *time.Time, matchingTags []string) (*model.ContentQueueRecord, error)
 	UpdateImportedContentDiscussionQueue(ctx context.Context, discussionID, contentID string) (*model.ContentQueueRecord, error)
+
+	// Helper functions
+	PostIterCollect(ctx context.Context, iter PostIter) ([]*model.Post, error)
 
 	// TXN
 	BeginTx(ctx context.Context) (*sql2.Tx, error)
@@ -207,6 +212,10 @@ func (d *delphisDB) initializeStatements(ctx context.Context) (err error) {
 	if d.prepStmts.getLastPostByDiscussionIDStmt, err = d.pg.PrepareContext(ctx, getLastPostByDiscussionIDStmt); err != nil {
 		logrus.WithError(err).Error("failed to prepare getLastPostByDiscussionIDStmt")
 		return errors.Wrap(err, "failed to prepare getLastPostByDiscussionIDStmt")
+	}
+	if d.prepStmts.getPostsByDiscussionIDFromCursorStmt, err = d.pg.PrepareContext(ctx, getPostsByDiscussionIDFromCursorString); err != nil {
+		logrus.WithError(err).Error("failed to prepare getPostsByDiscussionIDFromCursorStmt")
+		return errors.Wrap(err, "failed to prepare getPostsByDiscussionIDFromCursorStmt")
 	}
 	if d.prepStmts.putPostStmt, err = d.pg.PrepareContext(ctx, putPostString); err != nil {
 		logrus.WithError(err).Error("failed to prepare putPostStmt")

--- a/internal/datastore/post.go
+++ b/internal/datastore/post.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"io"
 	"time"
 
@@ -98,6 +99,12 @@ func (d *delphisDB) GetPostsByDiscussionIDFromCursorIter(ctx context.Context, di
 }
 
 func (d *delphisDB) GetPostsConnectionByDiscussionID(ctx context.Context, discussionID string, cursor string, limit int) (*model.PostsConnection, error) {
+	if limit < 2 {
+		err := errors.New("Values of 'limit' is illegal")
+		logrus.WithError(err).Error("GetPostsConnectionByDiscussionID::illegal limit parameter")
+		return nil, err
+	}
+
 	logrus.Debug("GetPostsConnectionByDiscussionID::SQL Query")
 	if err := d.initializeStatements(ctx); err != nil {
 		logrus.WithError(err).Error("GetPostsConnectionByDiscussionID::failed to initialize statements")

--- a/internal/datastore/prepared_statements.go
+++ b/internal/datastore/prepared_statements.go
@@ -5,9 +5,10 @@ import sql2 "database/sql"
 // Prepared Statements
 type dbPrepStmts struct {
 	// Post
-	getPostsByDiscussionIDStmt    *sql2.Stmt
-	getLastPostByDiscussionIDStmt *sql2.Stmt
-	putPostStmt                   *sql2.Stmt
+	getPostsByDiscussionIDStmt           *sql2.Stmt
+	getLastPostByDiscussionIDStmt        *sql2.Stmt
+	getPostsByDiscussionIDFromCursorStmt *sql2.Stmt
+	putPostStmt                          *sql2.Stmt
 
 	// PostContents
 	putPostContentsStmt *sql2.Stmt
@@ -59,7 +60,30 @@ const getPostsByDiscussionIDString = `
 		FROM posts p
 		INNER JOIN post_contents pc
 		ON p.post_content_id = pc.id
-		WHERE p.discussion_id = $1;`
+		WHERE p.discussion_id = $1
+		;`
+
+const getPostsByDiscussionIDFromCursorString = `
+		SELECT p.id,
+			p.created_at,
+			p.updated_at,
+			p.deleted_at,
+			p.deleted_reason_code,
+			p.discussion_id,
+			p.participant_id,
+			p.quoted_post_id,
+			p.media_id,
+			p.imported_content_id,
+			pc.id,
+			pc.content
+		FROM posts p
+		INNER JOIN post_contents pc
+		ON p.post_content_id = pc.id
+		WHERE p.discussion_id = $1
+		AND p.created_at < $2
+		ORDER BY p.created_at desc
+		LIMIT $3
+		;`
 
 const getLastPostByDiscussionIDStmt = `
 		SELECT p.id,


### PR DESCRIPTION
Implements all the changes we discussed this morning about the PostsConnection optimization (See #24). I didn't remove the simple post list query, so the frontend should not be broken while we migrate to this new approach.