### PR TITLE
Implemented deep-link redirection for twitter authentication on app

### DIFF
--- a/config/local.json
+++ b/config/local.json
@@ -49,7 +49,7 @@
     },
     "twitter": {
         "callback": "http://local.delphishq.com:8080/twitter/callback",
-        "redirect": "http://local.delphishq.com:8000"
+        "redirect": "delphis-chatham://local.delphishq.com:8000"
     },
     "s3_bucket": {
         "media_bucket": "static.chatham.ai",

--- a/config/staging.json
+++ b/config/staging.json
@@ -44,7 +44,7 @@
     },
     "twitter": {
         "callback": "https://staging.delphishq.com/twitter/callback",
-        "redirect": "https://app-staging.delphishq.com/"
+        "redirect": "delphis-chatham://app-staging.delphishq.com/"
     },
     "s3_bucket": {
         "media_bucket": "static.chatham.ai",


### PR DESCRIPTION
This is coupled to https://github.com/nedrocks/delphis_app/pull/47. Simply uses the app unique scheme for the final auth redirection in order to allow deep linking. The best approach would be to create a separate callback endpoint only for the app, in order to not break any web app. But this can be made in the future, as it requires an additional Twitter authorization.