### PR TITLE
Enabled support for push notification on android with FCM

### DIFF
--- a/internal/notif/ably_notif.go
+++ b/internal/notif/ably_notif.go
@@ -51,6 +51,10 @@ func SendPushNotification(ctx context.Context, config config.AblyConfig, device 
 		return true, nil
 	}
 
+	if device == nil || device.Token == nil {
+		return false, errors.New("Device token must not be nil")
+	}
+
 	var body []byte = nil
 	var err error = nil
 	if strings.ToLower(device.Platform) == "android" {

--- a/internal/notif/ably_notif.go
+++ b/internal/notif/ably_notif.go
@@ -52,7 +52,7 @@ func SendPushNotification(ctx context.Context, config config.AblyConfig, device 
 	}
 
 	if device == nil || device.Token == nil {
-		return false, errors.New("Device token must not be nil")
+		return false, fmt.Errorf("Device token must not be nil")
 	}
 
 	var body []byte = nil

--- a/internal/notif/ably_notif.go
+++ b/internal/notif/ably_notif.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/nedrocks/delphisbe/graph/model"
 	"github.com/nedrocks/delphisbe/internal/config"
@@ -24,27 +26,53 @@ type PushNotificationBody struct {
 	Body  string `json:"body"`
 }
 
-type PushNotificationRecipient struct {
+type ApnsPushNotificationRecipient struct {
 	TransportType transportType `json:"transportType"`
 	DeviceToken   string        `json:"deviceToken"`
 }
 
+type FcmPushNotificationRecipient struct {
+	TransportType     transportType `json:"transportType"`
+	RegistrationToken string        `json:"registrationToken"`
+}
+
 type ApplePushNotification struct {
-	Recipient    PushNotificationRecipient `json:"recipient"`
-	Notification PushNotificationBody      `json:"notification"`
+	Recipient    ApnsPushNotificationRecipient `json:"recipient"`
+	Notification PushNotificationBody          `json:"notification"`
+}
+
+type AndroidPushNotification struct {
+	Recipient    FcmPushNotificationRecipient `json:"recipient"`
+	Notification PushNotificationBody         `json:"notification"`
 }
 
 func SendPushNotification(ctx context.Context, config config.AblyConfig, device *model.UserDevice, pushBody PushNotificationBody) (bool, error) {
 	if !config.Enabled {
 		return true, nil
 	}
-	body, err := json.Marshal(ApplePushNotification{
-		Recipient: PushNotificationRecipient{
-			TransportType: "apns",
-			DeviceToken:   *device.Token,
-		},
-		Notification: pushBody,
-	})
+
+	var body []byte = nil
+	var err error = nil
+	if strings.ToLower(device.Platform) == "android" {
+		body, err = json.Marshal(AndroidPushNotification{
+			Recipient: FcmPushNotificationRecipient{
+				TransportType:     "fcm",
+				RegistrationToken: *device.Token,
+			},
+			Notification: pushBody,
+		})
+	} else if strings.ToLower(device.Platform) == "ios" {
+		body, err = json.Marshal(ApplePushNotification{
+			Recipient: ApnsPushNotificationRecipient{
+				TransportType: "apns",
+				DeviceToken:   *device.Token,
+			},
+			Notification: pushBody,
+		})
+	} else {
+		return false, errors.New("Unknown platform for device: " + device.Platform)
+	}
+
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Related to [https://github.com/nedrocks/delphis_app/pull/49](https://github.com/nedrocks/delphis_app/pull/49) and addresses [https://github.com/nedrocks/delphis_app/issues/46](https://github.com/nedrocks/delphis_app/issues/46). Enables push notification sending on Android platfroms, using Ably's APIs.